### PR TITLE
Python 3+ Compatibility

### DIFF
--- a/rure/decorators.py
+++ b/rure/decorators.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+
+def accepts_bytes(f):
+    """Decorator for instance methods that accept only byte strings as
+    first argument.
+    """
+    @wraps(f)
+    def wrapper(cls_instance, string, *args, **kwargs):
+        caller = "'{}.{}.{}'".format(
+            cls_instance.__module__,
+            type(cls_instance).__name__,
+            f.__name__
+        )
+        err_msg =  "{} requires a first argument of type 'bytes'".format(caller)
+        if not isinstance(string, bytes):
+            raise TypeError(err_msg)
+        return f(cls_instance, string, *args, **kwargs)
+    return wrapper
+
+
+def accepts_string(f):
+    """Decorator for instance methods that accept only unicode strings as
+    first argument.
+    """
+    @wraps(f)
+    def wrapper(cls_instance, string, *args, **kwargs):
+        caller = "'{}.{}.{}'".format(
+            cls_instance.__module__,
+            type(cls_instance).__name__,
+            f.__name__
+        )
+        err_msg =  "{} requires unicode string as its first argument".format(
+            caller)
+        if isinstance(string, bytes):
+            raise TypeError(err_msg)
+        return f(cls_instance, string, *args, **kwargs)
+    return wrapper

--- a/rure/exceptions.py
+++ b/rure/exceptions.py
@@ -1,5 +1,10 @@
+from __future__ import unicode_literals
+
+
 class RegexError(Exception):
-    pass
+    def __init__(self, message, *args):
+        super(RegexError, self).__init__(message, *args)
+        self.message = str(message)
 
 
 class RegexSyntaxError(RegexError):

--- a/rure/lib.py
+++ b/rure/lib.py
@@ -75,10 +75,14 @@ class Rure(object):
         """ Compiles a regular expression. Once compiled, it can be used
         repeatedly to search, split or replace text in a string.
 
-        :param re:      Expression to compile
+        :param re:      Bytestring expression to compile
         :param flags:   Bitmask of flags
         :param kwargs:  Config options to pass (size_limit, dfa_size_limit)
         """
+        if not isinstance(re, bytes):
+            raise TypeError("'rure.lib.Rure' must be instantiated with a "
+                            "bytestring as first argument.")
+
         self._err = ffi.gc(_lib.rure_error_new(), _lib.rure_error_free)
         self._opts = ffi.gc(_lib.rure_options_new(), _lib.rure_options_free)
 
@@ -88,9 +92,6 @@ class Rure(object):
         if 'dfa_size_limit' in options:
             _lib.rure_options_dfa_size_limit(self._opts,
                                              options['dfa_size_limit'])
-
-        if not isinstance(re, bytes):
-            self._warn(u'__init__')
 
         if re:
             s = checked_call(

--- a/rure/lib.py
+++ b/rure/lib.py
@@ -41,13 +41,14 @@ def checked_call(fn, err, *args):
     all_args = list(args) + [err]
     res = fn(*all_args)
     msg = ffi.string(_lib.rure_error_message(err))
-    if msg == 'no error':
+    if msg == b'no error':
         return res
-    elif msg.startswith('Error parsing regex'):
+    elif msg.startswith(b'Error parsing regex'):
         raise exceptions.RegexSyntaxError(msg)
-    elif msg.startswith('Compiled regex exceeds size limit'):
+    elif msg.startswith(b'Compiled regex exceeds size limit'):
         raise exceptions.CompiledTooBigError(msg)
     else:
+        msg = bytes(msg, 'utf8')
         raise exceptions.RegexError(msg)
 
 

--- a/rure/lib.py
+++ b/rure/lib.py
@@ -53,9 +53,6 @@ def checked_call(fn, err, *args):
         raise exceptions.RegexError(msg)
 
 
-B_WARN = u'Rure expects UTF8 byte strings: {}.{}::{}'
-
-
 class Rure(object):
     """ A compiled regular expression for matching Unicode strings.
 
@@ -111,13 +108,6 @@ class Rure(object):
             [i if i else '' for i in self.capture_names()],
             rename=True
         )
-
-    def _warn(self, mname):
-        warnings.warn(B_WARN.format(self.__class__.__module__,
-                                    self.__class__.__name__,
-                                    mname),
-                      UnicodeWarning,
-                      stacklevel=2)
 
     @accepts_bytes
     def capture_name_index(self, name):

--- a/rure/lib.py
+++ b/rure/lib.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 
 from rure._ffi import ffi
 from rure import exceptions
+from rure.decorators import accepts_bytes
 
 
 CASEI = 1 << 0
@@ -118,6 +119,7 @@ class Rure(object):
                       UnicodeWarning,
                       stacklevel=2)
 
+    @accepts_bytes
     def capture_name_index(self, name):
         """ Returns the capture index for the name given.
         If no such named capturing group exists in re, then -1 is returned.
@@ -127,9 +129,6 @@ class Rure(object):
         This function never returns 0 since the first capture group always
         corresponds to the entire match and is always unnamed.
         """
-        if not isinstance(name, bytes):
-            self._warn(u'capture_name_index')
-
         return _lib.rure_capture_name_index(self._ptr, name)
 
     def capture_names(self):
@@ -147,6 +146,7 @@ class Rure(object):
             else:
                 yield None
 
+    @accepts_bytes
     def is_match(self, haystack, start=0):
         """ Returns true if and only if the regex matches the string given.
 
@@ -154,9 +154,6 @@ class Rure(object):
         a match, since the underlying matching engine may be able to do less
         work.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'is_match')
-
         return bool(_lib.rure_is_match(
             self._ptr,
             haystack,
@@ -164,6 +161,7 @@ class Rure(object):
             start
         ))
 
+    @accepts_bytes
     def find(self, haystack, start=0):
         """ Returns the start and end byte range of the leftmost-first match
         in text. If no match exists, then None is returned.
@@ -172,9 +170,6 @@ class Rure(object):
         of the match. Testing the existence of a match is faster if you use
         is_match.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'find')
-
         match = ffi.new('rure_match *')
         if _lib.rure_find(
             self._ptr,
@@ -185,6 +180,7 @@ class Rure(object):
         ):
             return RureMatch(match.start, match.end)
 
+    @accepts_bytes
     def find_iter(self, haystack, start=0):
         """Returns the capture groups corresponding to the leftmost-first match
         in text. Capture group 0 always corresponds to the entire match.
@@ -194,9 +190,6 @@ class Rure(object):
         Otherwise, find is faster for discovering the location of the overall
         match.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'find_iter')
-
         hlen = len(haystack)
         find_iter = ffi.gc(_lib.rure_iter_new(self._ptr),
                            _lib.rure_iter_free)
@@ -208,6 +201,7 @@ class Rure(object):
                                   match):
             yield RureMatch(match.start, match.end)
 
+    @accepts_bytes
     def captures(self, haystack, start=0):
         """Returns the capture groups corresponding to the leftmost-first match
         in text. Capture group 0 always corresponds to the entire match.
@@ -217,9 +211,6 @@ class Rure(object):
         Otherwise, find is faster for discovering the location of the overall
         match.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'captures')
-
         hlen = len(haystack)
         captures = ffi.gc(_lib.rure_captures_new(self._ptr),
                           _lib.rure_captures_free)
@@ -237,14 +228,12 @@ class Rure(object):
                 if _lib.rure_captures_at(captures, i, match)
             ])
 
+    @accepts_bytes
     def captures_iter(self, haystack, start=0):
         """Returns an iterator over all the non-overlapping capture groups
         matched in text. This is operationally the same as find_iter,
         except it yields information about submatches.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'captures_iter')
-
         hlen = len(haystack)
         captures = ffi.gc(_lib.rure_captures_new(self._ptr),
                           _lib.rure_captures_free)
@@ -261,15 +250,13 @@ class Rure(object):
                 if _lib.rure_captures_at(captures, i, match)
             ])
 
+    @accepts_bytes
     def shortest_match(self, haystack, start=0):
         """Returns end location if and only if re matches anywhere in
         text. The end location is the place at which the regex engine
         determined that a match exists, but may occur before the end of
         the proper leftmost-first match.
         """
-        if not isinstance(haystack, bytes):
-            self._warn(u'shortest_match')
-
         hlen = len(haystack)
         end = ffi.new('size_t *')
         if _lib.rure_shortest_match(self._ptr, haystack, hlen, start, end):

--- a/rure/regex.py
+++ b/rure/regex.py
@@ -4,7 +4,7 @@ import warnings
 
 from rure import Rure
 from rure import DEFAULT_FLAGS
-from rure import CASEI, MULTI, DOTNL, SWAP_GREED, SPACE, UNICODE
+from rure import CASEI, MULTI, DOTNL, SPACE, UNICODE
 from rure.decorators import accepts_string
 
 
@@ -25,9 +25,6 @@ FLAG_NAMES = {
     re.UNICODE: 'UNICODE',
     re.VERBOSE: 'VERBOSE',
 }
-
-
-U_WARN = u'Expect undefined behavior by not passing a Unicode string to {}.{}::{}'
 
 
 class RegexObject(object):
@@ -60,13 +57,6 @@ class RegexObject(object):
             for pos, name in enumerate(names)
             if name is not None
         }
-
-    def _warn(self, mname):
-        warnings.warn(U_WARN.format(self.__class__.__module__,
-                                    self.__class__.__name__,
-                                    mname),
-                      UnicodeWarning,
-                      stacklevel=2)
 
     def capture_names(self):
         return self._rure.capture_names()

--- a/rure/regex.py
+++ b/rure/regex.py
@@ -5,6 +5,7 @@ import warnings
 from rure import Rure
 from rure import DEFAULT_FLAGS
 from rure import CASEI, MULTI, DOTNL, SWAP_GREED, SPACE, UNICODE
+from rure.decorators import accepts_string
 
 
 FLAG_MAP = {
@@ -30,10 +31,10 @@ U_WARN = u'Expect undefined behavior by not passing a Unicode string to {}.{}::{
 
 
 class RegexObject(object):
-
     def __init__(self, pattern, flags=0, **options):
         if isinstance(pattern, bytes):
-            self._warn(u'__init__')
+            raise TypeError("'rure.regex.RegexObject' must be instantiated with"
+                            " a unicode object as first argument.")
 
         self.flags = flags
         self.pattern = pattern.encode('utf8')
@@ -70,17 +71,13 @@ class RegexObject(object):
     def capture_names(self):
         return self._rure.capture_names()
 
+    @accepts_string
     def is_match(self, string, pos=0, endpos=None):
-        if isinstance(string, bytes):
-            self._warn(u'is_match')
-
         haystack = string[:endpos].encode('utf8')
         return self._rure.is_match(haystack, pos)
 
+    @accepts_string
     def search(self, string, pos=0, endpos=None):
-        if isinstance(string, bytes):
-            self._warn(u'search')
-
         haystack = string[:endpos].encode('utf8')
         if self.submatches:
             captures = self._rure.captures(haystack, pos)
@@ -91,29 +88,21 @@ class RegexObject(object):
             if match:
                 return MatchObject(pos, endpos, self, haystack, None)
 
+    @accepts_string
     def match(self, string, pos=0, endpos=None):
-        if isinstance(string, bytes):
-            self._warn(u'match')
-
         return self.search(r'\A' + string, pos, endpos)
 
+    @accepts_string
     def split(self, string, maxsplit=0):
-        if isinstance(string, bytes):
-            self._warn(u'split')
-
         # Not supported by the C library yet
         raise NotImplementedError
 
+    @accepts_string
     def findall(self, string, pos=0, endpos=None):
-        if isinstance(string, bytes):
-            self._warn(u'findall')
-
         return [match for match in self.finditer(string, pos, endpos)]
 
+    @accepts_string
     def finditer(self, string, pos=0, endpos=None):
-        if isinstance(string, bytes):
-            self._warn(u'finditer')
-
         haystack = string[:endpos].encode('utf8')
         if self.submatches:
             captures = self._rure.captures(haystack, pos)
@@ -123,17 +112,13 @@ class RegexObject(object):
             for match in self._rure.find_iter(haystack, pos):
                 yield MatchObject(pos, endpos, self, haystack, None)
 
+    @accepts_string
     def sub(self, repl, string, count=0):
-        if isinstance(string, bytes):
-            self._warn(u'sub')
-
         # Not supported by the C library yet
         raise NotImplementedError
 
+    @accepts_string
     def subn(self, repl, string, count=0):
-        if isinstance(string, bytes):
-            self._warn(u'subn')
-
         # Not supported by the C library yet
         raise NotImplementedError
 

--- a/test.py
+++ b/test.py
@@ -13,9 +13,9 @@ DEBUG = os.getenv('DEBUG', False)
 
 def test_is_match():
     passed = True
-    haystack = "snowman: \xE2\x98\x83"
+    haystack = b"snowman: \xE2\x98\x83"
 
-    re = Rure("\\p{So}$")
+    re = Rure(b"\\p{So}$")
     matched = re.is_match(haystack)
     if not matched:
         if DEBUG:
@@ -29,9 +29,9 @@ def test_is_match():
 
 def test_shortest_match():
     passed = True
-    haystack = "aaaaa"
+    haystack = b"aaaaa"
 
-    re = Rure("a+")
+    re = Rure(b"a+")
     end = re.shortest_match(haystack)
     if end is None:
         if DEBUG:
@@ -55,9 +55,9 @@ def test_shortest_match():
 
 def test_find():
     passed = True
-    haystack = "snowman: \xE2\x98\x83"
+    haystack = b"snowman: \xE2\x98\x83"
 
-    re = Rure("\\p{So}$")
+    re = Rure(b"\\p{So}$")
     match = re.find(haystack)
     if not match:
         if DEBUG:
@@ -82,9 +82,9 @@ def test_find():
 
 def test_captures():
     passed = True
-    haystack = "snowman: \xE2\x98\x83"
+    haystack = b"snowman: \xE2\x98\x83"
 
-    re = Rure(".(.*(?P<snowman>\\p{So}))$")
+    re = Rure(b".(.*(?P<snowman>\\p{So}))$")
     captures = re.captures(haystack)
     if not captures:
         if DEBUG:
@@ -94,7 +94,7 @@ def test_captures():
         passed = False
 
     expect_capture_index = 2
-    capture_index = re.capture_name_index("snowman")
+    capture_index = re.capture_name_index(b"snowman")
     if capture_index != expect_capture_index:
         if DEBUG:
             print("[test_captures] "
@@ -122,9 +122,9 @@ def test_captures():
 
 def test_iter():
     passed = True
-    haystack = "abc xyz"
+    haystack = b"abc xyz"
 
-    re = Rure("\\w+(\\w)")
+    re = Rure(b"\\w+(\\w)")
 
     match = next(re.find_iter(haystack))
     if not match:
@@ -188,7 +188,7 @@ def test_iter_capture_name(expect, given):
 def test_iter_capture_names():
     passed = True
 
-    re = Rure("(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})")
+    re = Rure(b"(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})")
 
     cn_iter = re.capture_names()
     result = next(cn_iter)
@@ -200,13 +200,13 @@ def test_iter_capture_names():
         passed = False
 
     name = next(cn_iter)
-    passed = test_iter_capture_name("year", name)
+    passed = test_iter_capture_name(b"year", name)
 
     name = next(cn_iter)
-    passed = test_iter_capture_name("month", name)
+    passed = test_iter_capture_name(b"month", name)
 
     name = next(cn_iter)
-    passed = test_iter_capture_name("day", name)
+    passed = test_iter_capture_name(b"day", name)
 
     return passed
 
@@ -217,7 +217,7 @@ def test_iter_capture_names():
 # (When Unicode mode is enabled, \xFF won't match .)
 def test_flags():
     passed = True
-    pattern = "."
+    pattern = b"."
     haystack = b"\xFF"
 
     re = Rure(pattern, flags=1)
@@ -244,7 +244,7 @@ def test_compile_error():
     #    passed = False
     #    rure_free(re)
     try:
-        re = Rure("(")
+        re = Rure(b"(")
         passed = False
     except RegexSyntaxError as err:
         if "Unclosed parenthesis" not in err.message:
@@ -271,7 +271,7 @@ def test_compile_error_size_limit():
     #    passed = False
     #    rure_free(re)
     try:
-        re = Rure("\\w{100}", size_limit=0)
+        re = Rure(b"\\w{100}", size_limit=0)
         passed = False
     except CompiledTooBigError as err:
         if "exceeds size" not in err.message:

--- a/test.py
+++ b/test.py
@@ -126,7 +126,7 @@ def test_iter():
 
     re = Rure("\\w+(\\w)")
 
-    match = re.find_iter(haystack).next()
+    match = next(re.find_iter(haystack))
     if not match:
         if DEBUG:
             print("[test_iter] expected first match, but got no match\n",
@@ -148,8 +148,8 @@ def test_iter():
     # find_iter and captures_iter use distinct iterators;
     # emulate by advancing captures an additional time
     c_iter = re.captures_iter(haystack)
-    c_iter.next()
-    captures = c_iter.next()
+    next(c_iter)
+    captures = next(c_iter)
     if not captures:
         if DEBUG:
             print("[test_iter] expected second match, but got no match\n",
@@ -191,7 +191,7 @@ def test_iter_capture_names():
     re = Rure("(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})")
 
     cn_iter = re.capture_names()
-    result = cn_iter.next()
+    result = next(cn_iter)
     if result is not None:
         if DEBUG:
             print("[test_iter_capture_names] expected None for the first unnamed capture\n",
@@ -199,13 +199,13 @@ def test_iter_capture_names():
 
         passed = False
 
-    name = cn_iter.next()
+    name = next(cn_iter)
     passed = test_iter_capture_name("year", name)
 
-    name = cn_iter.next()
+    name = next(cn_iter)
     passed = test_iter_capture_name("month", name)
 
-    name = cn_iter.next()
+    name = next(cn_iter)
     passed = test_iter_capture_name("day", name)
 
     return passed
@@ -288,9 +288,9 @@ def test_compile_error_size_limit():
 
 def run_test(test_func):
     if test_func():
-        print("PASSED: %s" % test_func.func_name, file=sys.stderr)
+        print("PASSED: %s" % test_func.__name__, file=sys.stderr)
     else:
-        print("FAILED: %s" % test_func.func_name, file=sys.stderr)
+        print("FAILED: %s" % test_func.__name__, file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch updates a few idioms that were changed from Python 2 -> 3, such as `generator.next()` vs. `next(generator)`.

Also, `bytes` string literals are used explicitly where needed. This has no change in Python 2.7.

Finally, the distinction between `rure.Rure` methods accepting `bytes` and `rure.RegexObject` accepting unicode strings as the first argument is made more obvious by dropping warnings in favor of exceptions. Two decorators are added in `rure.decorators` for this purpose. 