### PR TITLE
Add .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_ffi.py
+*.dylib
+*.dll
+*.so


### PR DESCRIPTION
Ignore `_ffi.py` created by the `cffi` lib, as well as the compiled `regex` library files.