### PR TITLE
Make stdlib's regex flag constants available here.

### DIFF
--- a/rure/__init__.py
+++ b/rure/__init__.py
@@ -1,3 +1,5 @@
+from re import LOCALE
+
 from rure.lib import Rure
 from rure.lib import DEFAULT_FLAGS
 from rure.lib import CASEI, MULTI, DOTNL, SWAP_GREED, SPACE, UNICODE
@@ -9,7 +11,17 @@ __all__ = [
     "compile", "search", "is_match", "match", "findall", "finditer",
     "DEFAULT_FLAGS",
     "CASEI", "MULTI", "DOTNL", "SWAP_GREED", "SPACE", "UNICODE",
+    "I", "IGNORECASE", "L", "LOCALE", "U", "M", "MULTILINE", "S",
+    "DOTALL", "X", "VERBOSE"
 ]
+
+# Make flag constants from stdlib re available here.
+I = IGNORECASE = CASEI
+L = LOCALE
+U = UNICODE
+M = MULTILINE = MULTI
+S = DOTALL = DOTNL
+X = VERBOSE = SPACE
 
 
 def compile(pattern, flags=0, **options):

--- a/rure/__init__.py
+++ b/rure/__init__.py
@@ -1,4 +1,4 @@
-from re import LOCALE
+import re
 
 from rure.lib import Rure
 from rure.lib import DEFAULT_FLAGS
@@ -16,12 +16,12 @@ __all__ = [
 ]
 
 # Make flag constants from stdlib re available here.
-I = IGNORECASE = CASEI
-L = LOCALE
-U = UNICODE
-M = MULTILINE = MULTI
-S = DOTALL = DOTNL
-X = VERBOSE = SPACE
+I = IGNORECASE = re.I
+L = LOCALE = re.L
+U = re.U
+M = MULTILINE = re.M
+S = DOTALL = re.S
+X = VERBOSE = re.X
 
 
 def compile(pattern, flags=0, **options):


### PR DESCRIPTION
This lets users do like

```python
import rure as re
reo = re.Rure(b"\\p{So}$", flags=re.IGNORECASE)
```