### PR TITLE
Ensure namedtuple field names are strings, not bytes, under Python 3.

### DIFF
--- a/rure/lib.py
+++ b/rure/lib.py
@@ -104,7 +104,7 @@ class Rure(object):
         self._ptr = ffi.gc(s, _lib.rure_free)
         self.capture_cls = namedtuple(
             'Captures',
-            [i if i else '' for i in self.capture_names()],
+            [i.decode('utf8') if i else '' for i in self.capture_names()],
             rename=True
         )
 


### PR DESCRIPTION
Passing byte strings to `namedtuple` with `rename=True` will result in
all field names replaced with underscore + digit. In Python 3, byte
strings must be decoded to utf8.

In Python 2.7:

```python
        self.capture_cls = namedtuple(
            'Captures',
            [i if i else '' for i in self.capture_names()],
            rename=True
        )
        self.capture_cls._fields
        >> ['_0', 'x', 'y']
```

In Python 3.5:

```python
        self.capture_cls = namedtuple(
            'Captures',
            [i if i else '' for i in self.capture_names()],
            rename=True
        )
        self.capture_cls._fields
        >> ['_0', '_1', '_2']
```

This is because the field names as passed to `namedtuple` are bytes, not strings. Field name identifiers must be strings.