### PR TITLE
Replace TestCase method deprecated in Python 3.

### DIFF
--- a/rure/tests/test_regexobject.py
+++ b/rure/tests/test_regexobject.py
@@ -53,5 +53,5 @@ class TestRegexObject(unittest.TestCase):
         self.assertIsNotNone(results)
         self.assertEqual(len(results.groups()),
                          len(stdlib_results.groups()))
-        self.assertItemsEqual(results.group(0),
-                              stdlib_results.group(0))
+        self.assertEqual(sorted(results.group(0)),
+                         sorted(stdlib_results.group(0)))


### PR DESCRIPTION
`TestCase.assertItemsEqual` is deprecated, so this patch replaces with
its equivalent.