### PR TITLE
fix empty regex check

### DIFF
--- a/rure/lib.py
+++ b/rure/lib.py
@@ -72,7 +72,7 @@ class Rure(object):
             _native.lib.rure_options_dfa_size_limit(self._opts,
                                              options['dfa_size_limit'])
 
-        if re:
+        if re is not None:
             s = checked_call(
                 _native.lib.rure_compile,
                 self._err,


### PR DESCRIPTION
This fixes an issue where an empty string causes a `TypeError` because a string gets passed to `ffi.gc`